### PR TITLE
revert sidebar background color back to pre 4.3.0 changes

### DIFF
--- a/_sass/colors/light-typography.scss
+++ b/_sass/colors/light-typography.scss
@@ -28,9 +28,9 @@
   --checkbox-checked-color: #07a8f7;
 
   /* Sidebar */
-  --sidebar-bg: #eeeeee;
+  --sidebar-bg: radial-gradient(circle, rgba(42, 30, 107, 1) 0%, rgba(35, 37, 46, 1) 100%);
   --sidebar-muted-color: #a2a19f;
-  --sidebar-active-color: #424242;
+  --sidebar-active-color: rgb(255 255 255 / 80%);
   --nav-cursor-color: #757575;
   --sidebar-btn-bg: white;
 


### PR DESCRIPTION
This is what it looked like pre-4.3.0 (commit dda9b350ebc770f894c7bfd59749e868d2c2dd28):
![image](https://user-images.githubusercontent.com/19912012/147787346-05e53dfb-82cc-4943-bd2d-c09e826bd8f9.png)


This is what the color looks like now (4.3.0 commit b1dde3ff7d5d956902b027b18dd511a4e7306a6d):
![image](https://user-images.githubusercontent.com/19912012/147787227-b0364354-c8b4-40c6-bee4-ad11a7aa66db.png)

This is what we are changing it to (pre 4.3.0 sidebar color style, commit 40d517acd32e2c8c5998d5e9531ed56244c12dd8): 
![image](https://user-images.githubusercontent.com/19912012/147787264-7eb81c07-2e89-4e29-9aa2-34d2522d97d3.png)



