### PR TITLE
tucking in list item margins

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ See: [#8](https://github.com/joshjohanning/joshjohanning.github.io/pull/8)
 
 Used an icon from [fontawesome](https://fontawesome.com/v4/icons/).
 
+### Tucking in List Item Margins
+
+See: [#18](https://github.com/joshjohanning/joshjohanning.github.io/pull/18)
+
 ## Upgrading the Theme
 
 Since we aren't using the theme gem (so we can do customizations), we have to do it the old-fashioned way: 

--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -468,14 +468,14 @@ img[data-src] {
     margin: 1.25rem 0;
 
     li {
-      margin: 0.5rem 0;
+      margin: 0.0rem 0;
       padding-left: 0.4rem;
     }
 
     ol,
     ul {
       padding-inline-start: $start-padding;
-      margin: 0.75rem 0;
+      margin: 0.0rem 0;
     }
   }
 


### PR DESCRIPTION
## Changing from this:

![image](https://user-images.githubusercontent.com/19912012/194092895-0475e8ac-d27f-4446-9f8f-ed5d81d12445.png)

## To this:

![image](https://user-images.githubusercontent.com/19912012/194093024-3496c674-e3cc-4304-858e-6c27a570f32b.png)

This has `0.0` margin for both `<ul>` and `<li>`.

See related discussion: https://github.com/cotes2020/jekyll-theme-chirpy/pull/703