### PR TITLE
Fix google_site_verification HTML Tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ social:
     # - https://www.facebook.com/username
     - https://www.linkedin.com/in/joshua-johanning/
 
-google_site_verification: google-site-verification=eTIC71VhPBtwll8rNv7qlXud1yJh6E88No39MdcM_MI # change to your verification string
+google_site_verification: eTIC71VhPBtwll8rNv7qlXud1yJh6E88No39MdcM_MI # change to your verification string
 
 # ↑ --------------------------
 # The end of `jekyll-seo-tag` settings


### PR DESCRIPTION
Current value is giving wrong HTML tag:

```html
<meta name="google-site-verification" content="google-site-verification=xxxxxxxxxxxxxxxxxxxx" />
```

The correct one is without `google-site-verification=` prefix...